### PR TITLE
Things I have already done in production to support CommonApp Jitterbit

### DIFF
--- a/force-app/main/default/objects/Application__c/fields/External_Application_ID__c.field-meta.xml
+++ b/force-app/main/default/objects/Application__c/fields/External_Application_ID__c.field-meta.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>External_Application_ID__c</fullName>
-    <description>External application system unique ID. Example: Common App, Nursing CAS, ELS</description>
+    <caseSensitive>false</caseSensitive>
+    <deprecated>false</deprecated>
+    <description>External application system unique ID. Example uses: Common App, Nursing CAS, ELS.
+
+DO NOT DELETE this field.  DO NOT REMOVE its &quot;external ID&quot; setting.  DO NOT REMOVE its &quot;unique case-insensitive&quot; constraint.  All of these requirements are essential to avoid breaking data-loads from CommonApp into Salesforce via Jitterbit.  Thank you!</description>
     <externalId>true</externalId>
     <inlineHelpText>External application system unique ID. Example: Common App, Nursing CAS, ELS</inlineHelpText>
     <label>External Application ID</label>
     <length>20</length>
     <required>false</required>
     <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
     <type>Text</type>
-    <unique>false</unique>
+    <unique>true</unique>
 </CustomField>

--- a/force-app/main/default/objects/Contact/fields/Common_App_Student_ID__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/Common_App_Student_ID__c.field-meta.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Common_App_Student_ID__c</fullName>
-    <description>Common App Unique Student ID</description>
+    <caseSensitive>false</caseSensitive>
+    <deprecated>false</deprecated>
+    <description>Common App Unique Student ID
+
+DO NOT DELETE this field.  DO NOT REMOVE its &quot;external ID&quot; setting.  DO NOT REMOVE its &quot;unique case-insensitive&quot; constraint.  All of these requirements are essential to avoid breaking data-loads from CommonApp into Salesforce via Jitterbit.  Thank you!</description>
     <externalId>true</externalId>
     <label>Common App Student ID</label>
     <length>20</length>
     <required>false</required>
     <trackFeedHistory>false</trackFeedHistory>
     <type>Text</type>
-    <unique>false</unique>
+    <unique>true</unique>
 </CustomField>


### PR DESCRIPTION
# Changes I already made in production to support CommonApp Jitterbit

This is ready to merge into the "master" branch.

## Edited fields

1. `Contact.Common_App_Student_ID__c` -- added unique constraint and updated description _(9/26/22, 1PM-ish, [commit 17ddb61](https://github.com/UniversityOfSaintThomas/UST-EASY/commit/17ddb6127e4337fd9de7015f1530d0ea0a652a52))_ 
1. `Application__c.External_Application_ID__c` -- added unique constraint and updated description _(9/26/22, 1PM-ish, [commit 17ddb61](https://github.com/UniversityOfSaintThomas/UST-EASY/commit/17ddb6127e4337fd9de7015f1530d0ea0a652a52))_

## Quality assurance

### Tests run in prod

1. Ran `sfdx force:apex:test:run --testlevel RunLocalTests` in EDA-Salesforce-PROD.  Forgot to do it before deployment, but ran after _(9/26/22, 5PMish)_.  Same country errors _(and that one error found in the before-and-after of pull request #70)_ after deployment of [commit 17ddb61](https://github.com/UniversityOfSaintThomas/UST-EASY/commit/17ddb6127e4337fd9de7015f1530d0ea0a652a52).

### Scratch org spinup

1. Ran `cci flow run dev_org --org dev` from within this branch _(9/26/22, 5PM-6PMish, [commit 17ddb61](https://github.com/UniversityOfSaintThomas/UST-EASY/commit/17ddb6127e4337fd9de7015f1530d0ea0a652a52))_.  Spun up without issue and `cci org browser --org dev` opened an org that had my new fields and permission set in it.