### PR TITLE
Rec update

### DIFF
--- a/force-app/main/default/classes/ApplicationRequirement.cls
+++ b/force-app/main/default/classes/ApplicationRequirement.cls
@@ -552,6 +552,7 @@ public class ApplicationRequirement {
                     SELECT Id, Recommendation_Requirement_Response__c, Rec_Email__c
                     FROM Recommendation__c 
                     WHERE Recommendation_Requirement_Response__c IN: rr_ids_that_should_have_recommendation
+                    AND Submitted__c = false
                 ];
 
                 Map<Id, Recommendation__c> requirement_response_to_recommendation_map = new Map<Id, Recommendation__c>();
@@ -560,11 +561,19 @@ public class ApplicationRequirement {
                 }
 
                 List<Recommendation__c> recs_to_upsert = new List<Recommendation__c>();
+                List<Recommendation__c> recs_to_delete = new List<Recommendation__c>();
                 for (Id rr_id : rr_ids_that_should_have_recommendation) {
                     if (String.isNotBlank(rrMap.get(rr_id).External_Email__c)) {
                         Recommendation__c related_rec;
                         if (requirement_response_to_recommendation_map.get(rr_id) != null) { // recommendation already exists
                             related_rec = requirement_response_to_recommendation_map.get(rr_id);
+                            if (related_rec.Rec_Email__c != rrMap.get(rr_id).External_Email__c) { // recommendation exists but email has changed
+                                recs_to_delete.add(related_rec);
+                                related_rec = new Recommendation__c();
+                                related_rec.Application__c = rrMap.get(rr_id).Application__c;
+                                related_rec.Recommendation_Requirement_Response__c = rr_id;
+                                related_rec.Status__c = 'Requested';
+                            }
                         } else { // create new recommendation
                             related_rec = new Recommendation__c();
                             related_rec.Application__c = rrMap.get(rr_id).Application__c;
@@ -581,6 +590,10 @@ public class ApplicationRequirement {
                             }
                             recs_to_upsert.add(related_rec);
                     }
+                }
+
+                if (recs_to_delete != null) {
+                    delete recs_to_delete;
                 }
 
                 if (recs_to_upsert != null) {

--- a/force-app/main/default/classes/ApplicationRequirement.cls
+++ b/force-app/main/default/classes/ApplicationRequirement.cls
@@ -549,10 +549,9 @@ public class ApplicationRequirement {
 
                 // get existing recommendations
                 List<Recommendation__c> recommendations_related_to_requirement_responses = [
-                    SELECT Id, Recommendation_Requirement_Response__c, Rec_Email__c
+                    SELECT Id, Recommendation_Requirement_Response__c, Rec_Email__c, Submitted__c
                     FROM Recommendation__c 
                     WHERE Recommendation_Requirement_Response__c IN: rr_ids_that_should_have_recommendation
-                    AND Submitted__c = false
                 ];
 
                 Map<Id, Recommendation__c> requirement_response_to_recommendation_map = new Map<Id, Recommendation__c>();
@@ -567,7 +566,7 @@ public class ApplicationRequirement {
                         Recommendation__c related_rec;
                         if (requirement_response_to_recommendation_map.get(rr_id) != null) { // recommendation already exists
                             related_rec = requirement_response_to_recommendation_map.get(rr_id);
-                            if (related_rec.Rec_Email__c != rrMap.get(rr_id).External_Email__c) { // recommendation exists but email has changed
+                            if (related_rec.Rec_Email__c != rrMap.get(rr_id).External_Email__c && related_rec.Submitted__c != true) { // recommendation exists but email has changed, create new rec and delete old
                                 recs_to_delete.add(related_rec);
                                 related_rec = new Recommendation__c();
                                 related_rec.Application__c = rrMap.get(rr_id).Application__c;
@@ -588,7 +587,9 @@ public class ApplicationRequirement {
                                     }
                                 }
                             }
-                            recs_to_upsert.add(related_rec);
+                            if (related_rec.Submitted__c != true) {
+                                recs_to_upsert.add(related_rec);
+                            }
                     }
                 }
 


### PR DESCRIPTION

# Critical Changes

# Changes
If an applicant changes a recommender's email, a new recommendation is created and the previous object is deleted (so the link is no longer valid). 
If an applicant changes a recommender's email and the recommendation has already been submitted, the recommendation is not updated (to avoid an applicant sending the request to themselves, submitting it, then changing the email)
# Issues Closed
