### PR TITLE
Added only one matching key to stop duplicate widgets, ignores status…

### DIFF
--- a/force-app/main/default/classes/ApplicationBodyController.cls
+++ b/force-app/main/default/classes/ApplicationBodyController.cls
@@ -56,6 +56,7 @@ public with sharing class ApplicationBodyController {
                             Intended_Term_of_Entry__r.Name, Intended_Program__r.Name, Citizenship__c
                     FROM Application__c
                     WHERE Contact__c = :appInfoParam.contactId
+                    AND Application_Status__c != 'Wrong Application'
             ]) {
                 appInfoIds.add(app.Application_Control__r.Id);
                 String atURL = app.Application_Control__r.URL_Parameter__c;
@@ -107,7 +108,8 @@ public with sharing class ApplicationBodyController {
                     SELECT Id, Name, Display_Text__c, Scripts__c, Widget_Screen_Location__c, Display_Heading__c,
                             Widget_Type__c, Sort_Order__c, Display_Widget_On_Pages__c, Display_Widget_On_Status__c,
                             Display_Widget_On_Sub_Status__c, Application_Control__r.URL_Parameter__c, Activation_State__c,
-                            Start_Date__c, End_Date__c, Start_Time__c, End_Time__c, Widget_Time_Zone__c, Display_Widget_On_Citizenship__c
+                            Start_Date__c, End_Date__c, Start_Time__c, End_Time__c, Widget_Time_Zone__c, Display_Widget_On_Citizenship__c,
+                            Only_One_Widget_Key__c
                     FROM EASY_Widget__c
                     WHERE Application_Control__c IN :appInfoIds
                     AND Display_Widget_On_Pages__c INCLUDES (:currentPageName)
@@ -160,6 +162,14 @@ public with sharing class ApplicationBodyController {
                         skipWidget = true;
                     } else {
                         onlyOneWidgetPerPage.put(widget.Widget_Type__c, onlyOneWidgetPerPage.get(widget.Widget_Type__c) + 1);
+                    }
+                }
+
+                if (String.isNotBlank(widget.Only_One_Widget_Key__c) & !skipWidget) {
+                    if (onlyOneWidgetPerPage.containsKey(widget.Only_One_Widget_Key__c)) {
+                        skipWidget = true;
+                    } else {
+                        onlyOneWidgetPerPage.put(widget.Only_One_Widget_Key__c, 1);
                     }
                 }
 

--- a/force-app/main/default/classes/ApplicationPortal.cls
+++ b/force-app/main/default/classes/ApplicationPortal.cls
@@ -50,7 +50,7 @@ public class ApplicationPortal {
                 List<Id> appControlIdsList = new List<Id>(appControlsByAppIds.keySet());
                 String appFields = ApplicationHelper.getAllItemApplicationFieldsByAppControlId(appControlIdsList);
 
-                String query = 'SELECT ' + appFields + ' FROM Application__c WHERE Contact__c = \'' + contactId + '\''; //+ '\' AND Application_Control__r.Id IN :appControlIdsList';
+                String query = 'SELECT ' + appFields + ' FROM Application__c WHERE Contact__c = \'' + contactId + '\' AND Application_Status__c != \'Wrong Application\'' ; //+ '\' AND Application_Control__r.Id IN :appControlIdsList';
 
                 applicationsByIds = new Map<Id, Application__c>((List<Application__c>) Database.query(query));
                 applicationMapSize = applicationsByIds.size();

--- a/force-app/main/default/layouts/EASY_Widget__c-EASY Widget Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/EASY_Widget__c-EASY Widget Layout.layout-meta.xml
@@ -26,6 +26,10 @@
                 <behavior>Edit</behavior>
                 <field>Scripts__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Only_One_Widget_Key__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/force-app/main/default/objects/EASY_Widget__c/fields/Only_One_Widget_Key__c.field-meta.xml
+++ b/force-app/main/default/objects/EASY_Widget__c/fields/Only_One_Widget_Key__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Only_One_Widget_Key__c</fullName>
+    <description>If entered, the text in this field will be used to find matching text in this field among widgets. If a widget with the same key is found it will skip showing that widget allowing only one of this key type to appear on a page.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>If entered, the text in this field will be used to find matching text in this field among widgets. If a widget with the same key is found it will skip showing that widget allowing only one of this key type to appear on a page.</inlineHelpText>
+    <label>Only One Widget Key</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/permissionsets/Application_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Application_Admin.permissionset-meta.xml
@@ -1026,6 +1026,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>EASY_Widget__c.Only_One_Widget_Key__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>EASY_Widget__c.Scripts__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/Application_Community.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Application_Community.permissionset-meta.xml
@@ -462,6 +462,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>EASY_Widget__c.Only_One_Widget_Key__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>EASY_Widget__c.Scripts__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/Application_Community_Guest.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Application_Community_Guest.permissionset-meta.xml
@@ -378,6 +378,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>EASY_Widget__c.Only_One_Widget_Key__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>EASY_Widget__c.Scripts__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
… Wrong Application



# Critical Changes

# Changes

- Created a field called only one widget key. It allows to user to create unique key to provide to widgets. When the key is found only the first widget will display
- Applications with the status "Wrong Application" will no longer appear in the porta.

# Issues Closed
