### PR TITLE
App check on reg

### DIFF
--- a/force-app/main/default/classes/ApplicationRegistration.cls
+++ b/force-app/main/default/classes/ApplicationRegistration.cls
@@ -159,7 +159,16 @@ public class ApplicationRegistration {
 
             insert interaction;
             interaction = [
-                    SELECT Id, Contact__c, First_Name__c, Middle_Name__c, Last_Name__c, Email__c, External_Application_ID__c
+                    SELECT
+                            Id,
+                            Contact__c,
+                            First_Name__c,
+                            Middle_Name__c,
+                            Last_Name__c,
+                            Email__c,
+                            External_Application_ID__c,
+                            Academic_Program__c,
+                            Intended_Start_Term__c
                     FROM Interaction__c
                     WHERE Id = :interaction.Id
             ];
@@ -170,9 +179,46 @@ public class ApplicationRegistration {
             ];
             appCreate.con.Id = con.Id;
 
+
             // Exit and roll-back if User with Email or Contact already exists
             if (![SELECT Id FROM User WHERE Username = :con.Email OR ContactId = :con.Id LIMIT 1].isEmpty()) {
                 throw new ApplicationUtilities.ApplicationException(' An account with this email already exists. Please sign in with the button to the right for existing users."', true, true);
+            }
+
+            if (String.isNotBlank(interaction.Academic_Program__c)) {
+                List<Application__c> a = [
+                        SELECT
+                                Id,
+                                Intended_Program__c,
+                                Intended_Program__r.Number_of_Applications_Limit__c,
+                                Intended_Term_of_Entry__c,
+                                Application_Status__c,
+                                Application_Substatus__c,
+                                Applicant_Type__c
+                        FROM Application__c
+                        WHERE Contact__r.Email = :con.Email
+                        AND Application_Status__c != 'Wrong Application'
+                        AND (NOT (Application_Status__c = 'Withdrawn' AND Application_Substatus__c = 'Wrong App'))
+                        AND (NOT (Application_Status__c = 'Withdrawn' AND Application_Substatus__c = 'Multiple App'))
+                        AND Applicant_Type__c = 'Common App'
+                        AND Intended_Program__c = :interaction.Academic_Program__c
+                        AND Intended_Program__r.Number_of_Applications_Limit__c LIKE 'One Application%'
+                        AND Intended_Term_of_Entry__c = :interaction.Intended_Start_Term__c
+                ];
+
+                Application_Setting__c AppSettings = Application_Setting__c.getOrgDefaults();
+                String currentUrl = AppSettings.Community_URL__c;
+                if (!currentUrl.endsWith('/')) {
+                    currentUrl += '/';
+                }
+                currentUrl += 'ApplicationRegistration?at=commonapp';
+                if (!currentUrl.startsWith('http')) {
+                    currentUrl = 'https://' + currentUrl;
+                }
+
+                if (a.size() > 0) {
+                    throw new ApplicationUtilities.ApplicationException('You have an unclaimed common app. Please <a href="' + currentUrl + '">follow this link to claim it</a>.', true, true);
+                }
             }
 
             // Update Account owner to Site admin if owner is current user (guest user)
@@ -319,16 +365,15 @@ public class ApplicationRegistration {
 
 
         if (interaction.Academic_Program__c != null) {
-            List<Program__c> program = [
+            Program__c program = [
                     SELECT Id, Program_College_of_Interest__c, Program_Applicant_Type__c
                     FROM Program__c
                     WHERE Id = :interaction.Academic_Program__c
-                    LIMIT 1
             ];
 
-            if (!program.isEmpty()) {
-                interaction.College_of_Interest__c = program[0].Program_College_of_Interest__c;
-                interaction.Admit_Type__c = program[0].Program_Applicant_Type__c;
+            if (program != null) {
+                interaction.College_of_Interest__c = program.Program_College_of_Interest__c;
+                interaction.Admit_Type__c = program.Program_Applicant_Type__c;
             }
 
             List<Plan__c> relatedPlan = [

--- a/force-app/main/default/classes/ApplicationRegistration.cls
+++ b/force-app/main/default/classes/ApplicationRegistration.cls
@@ -217,7 +217,7 @@ public class ApplicationRegistration {
                 }
 
                 if (a.size() > 0 && !commonAppApplication) {
-                    throw new ApplicationUtilities.ApplicationException('You have an unclaimed common app. Please <a href="' + currentUrl + '">follow this link to claim it</a>.', true, true);
+                    throw new ApplicationUtilities.ApplicationException('You need to claim your Common App application. <a href="' + currentUrl + '">Please follow this link for more information and to claim your account</a>.', true, true);
                 }
             }
 

--- a/force-app/main/default/classes/ApplicationRegistration.cls
+++ b/force-app/main/default/classes/ApplicationRegistration.cls
@@ -216,7 +216,7 @@ public class ApplicationRegistration {
                     currentUrl = 'https://' + currentUrl;
                 }
 
-                if (a.size() > 0) {
+                if (a.size() > 0 && !commonAppApplication) {
                     throw new ApplicationUtilities.ApplicationException('You have an unclaimed common app. Please <a href="' + currentUrl + '">follow this link to claim it</a>.', true, true);
                 }
             }

--- a/force-app/main/default/components/ApplicationForm.component
+++ b/force-app/main/default/components/ApplicationForm.component
@@ -9,7 +9,7 @@
     <apex:attribute name="title" description="Title of current section" type="String" required="false"/>
     <apex:form id="theForm">
         <apex:outputPanel id="formPageMessages">
-            <apex:pageMessages />
+            <apex:pageMessages escape="false"/>
         </apex:outputPanel>
 
         <apex:commandLink id="reRenderGroups" value="" style="display:none;" action="{!section.pushValuesToObjects}" onComplete="pageLoadReRendered();" reRender="{!$Component.groupRepeat.theFormSectionComponent.applicationFormSectionComponent.questionGroupWrapper}"/>
@@ -51,6 +51,6 @@
                 </div>
             </div>
         </div>
-        <apex:componentBody />
+        <apex:componentBody/>
     </apex:form>
 </apex:component>

--- a/force-app/main/default/staticresources/EasyAppResources/js/scripts.js
+++ b/force-app/main/default/staticresources/EasyAppResources/js/scripts.js
@@ -1,9 +1,15 @@
-let ready = (callback) => {
-    if (document.readyState !== "loading") callback();
-    else document.addEventListener("DOMContentLoaded", callback);
+
+function docReady(fn) {
+    // see if DOM is already available
+    if (document.readyState === "complete" || document.readyState === "interactive") {
+
+        setTimeout(fn, 1);
+    } else {
+        document.addEventListener("DOMContentLoaded", fn);
+    }
 }
 
-ready(() => {
+docReady(function() {
     appHideLoadingSpinner();
     pageLoadReRendered();
     activateCarousel();
@@ -13,6 +19,7 @@ function pageLoadReRendered() {
 
     //Disable fields that are set to not be editable
     let sldsScope = document.querySelector('.slds-scope');
+
     sldsScope.querySelectorAll('.fieldNotEditable, .fieldNotEditable input, .fieldNotEditable select, .fieldNotEditable textarea').forEach(field => {
         field.setAttribute('disabled', 'disabled');
     });


### PR DESCRIPTION

# Critical Changes

# Changes

- Logic added to registration page to detect if an existing first year undergrad common app exists in our system that has not been claimed by a registrant who is attempting to start a new non-common app version with the same term. The user is redirected to claim the common app. 

# Issues Closed
