### PR TITLE
fixed null object defined in spinner javascript

### DIFF
--- a/force-app/main/default/staticresources/EasyAppResources/js/scripts.js
+++ b/force-app/main/default/staticresources/EasyAppResources/js/scripts.js
@@ -892,7 +892,6 @@ function showFormSpinner() {
 }
 
 function showFormSpinnerRelatedRecord() {
-    spinnerFocusElement = document.activeElement.parentElement.parentElement.parentElement;
     if (document.getElementById('form-spinner')) {
         document.getElementById("form-spinner").style.display = 'block';
     }


### PR DESCRIPTION

# Critical Changes

# Changes
- Removed variable assignment that was not used and was causing Safari browser to no allow a record form to appear.

# Issues Closed
